### PR TITLE
deva-gap: Fix respec variables

### DIFF
--- a/gap-analysis/deva-gap.html
+++ b/gap-analysis/deva-gap.html
@@ -10,13 +10,13 @@
   <script class="remove" type="text/javascript">
   var respecConfig = {
       // specification status (e.g. WD, LCWD, WG-NOTE, etc.). If in doubt use ED.
-      specStatus:           "ED",
-      //publishDate:  		"2015-07-21",
-      //previousPublishDate:  "2014-12-16",
-      //previousMaturity:  "FPWD",
+      specStatus:            "ED",
+      //publishDate:  	     "2015-07-21",
+      //previousPublishDate: "2014-12-16",
+      //previousMaturity:    "FPWD",
 
       noRecTrack:           true,
-      shortName:            "taml-gap",
+      shortName:            "deva-gap",
       copyrightStart:       "2018",
       edDraftURI:           "https://w3c.github.io/iip/gap-analysis/",
 
@@ -50,7 +50,7 @@
       // langs array lists languages addressed by this document, in order of speaker (highest first)
       // it is used to generate the javascript needed for the matrix
       langs: ['Hindi','Marathi'],
-      gapDocPath: 'https://w3c.github.io/iip/gap-analysis/',
+      gapDocPath: 'https://w3c.github.io/iip/gap-analysis/deva-gap',
 
 
       // URI of the patent status for this WG, for Rec-track documents


### PR DESCRIPTION
Should make the summary tool produce the right URL for the language matrix.